### PR TITLE
Add simple layout preview

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,6 +15,7 @@ import { TextBox } from './textBox/TextBox';
 import { TopNav } from './topNav/TopNav';
 import { WeddingName } from './weddingName/WeddingName';
 import { DualPanePreview } from './preview/web/dualPane/DualPanePreview';
+import { SimpleLayoutPreview } from './preview/web/simpleLayout/SimpleLayoutPreview';
 import { CountdownTimer } from './countdownTimer/CountdownTimer';
 import { SpinnerLoader } from './loader/SpinnerLoader';
 
@@ -39,6 +40,7 @@ export {
   TextBox,
   WeddingName,
   DualPanePreview,
+  SimpleLayoutPreview,
   CountdownTimer,
   SpinnerLoader
 };

--- a/src/components/preview/web/PreviewWrapper.tsx
+++ b/src/components/preview/web/PreviewWrapper.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { css } from 'glamor';
+import { Observable } from 'rxjs';
+import { VelocityComponent } from 'velocity-react';
+
+const SIDE_MARGIN = 20;
+
+export interface Props {
+  for: For;
+  previewOptions: {
+    height?: number;
+    width?: number;
+  };
+}
+
+export type For = 'dualPane' | 'simpleLayout';
+
+const previewWrapperRules = css({
+  height: '100%',
+  width: '100%',
+  position: 'relative'
+});
+
+export class PreviewWrapper extends React.Component<Props> {
+  private windowResizeSub;
+  private previewContainer;
+
+  state = { scale: 1 };
+
+  componentDidMount() {
+    this.previewContainer = document.getElementById(
+      `${this.props.for}PreviewContainer`
+    );
+    this.setWindowResizeSubscription();
+    this.updatePreviewScale();
+  }
+
+  componentWillUnmount() {
+    this.windowResizeSub && this.windowResizeSub.unsubscribe();
+  }
+
+  private setWindowResizeSubscription = () => {
+    const windowResize$ = Observable.fromEvent(window, 'resize');
+    this.windowResizeSub = windowResize$.debounceTime(250).subscribe({
+      next: evt => {
+        this.updatePreviewScale();
+      }
+    });
+  };
+
+  private updatePreviewScale = () => {
+    const { width } = this.props.previewOptions;
+    const containerToPreviewRatio =
+      (this.previewContainer.offsetWidth - SIDE_MARGIN * 2) / width;
+    if (containerToPreviewRatio < 1) {
+      this.setState({ scale: containerToPreviewRatio });
+    } else if (containerToPreviewRatio !== 1) {
+      this.setState({ scale: 1 });
+    }
+  };
+
+  render() {
+    return (
+      <div
+        id={`${this.props.for}PreviewContainer`}
+        data-website-preview={this.props.for}
+        {...previewWrapperRules}
+      >
+        <VelocityComponent
+          animation={{
+            translateZ: 0.001,
+            translateX: '-50%',
+            translateY: '-50%',
+            scale: this.state.scale
+          }}
+          easing="ease"
+        >
+          {/* transform: `translateZ(0) translate(-50%,-50%) scale(${scale})`, */}
+          {this.props.children}
+        </VelocityComponent>
+      </div>
+    );
+  }
+}

--- a/src/components/preview/web/PreviewWrapper.tsx
+++ b/src/components/preview/web/PreviewWrapper.tsx
@@ -7,7 +7,7 @@ const SIDE_MARGIN = 20;
 
 export interface Props {
   for: For;
-  previewOptions: {
+  previewOptions?: {
     height?: number;
     width?: number;
   };
@@ -18,7 +18,10 @@ export type For = 'dualPane' | 'simpleLayout';
 const previewWrapperRules = css({
   height: '100%',
   width: '100%',
-  position: 'relative'
+  position: 'relative',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center'
 });
 
 export class PreviewWrapper extends React.Component<Props> {
@@ -60,6 +63,7 @@ export class PreviewWrapper extends React.Component<Props> {
   };
 
   render() {
+    const { previewOptions } = this.props;
     return (
       <div
         id={`${this.props.for}PreviewContainer`}
@@ -69,8 +73,8 @@ export class PreviewWrapper extends React.Component<Props> {
         <VelocityComponent
           animation={{
             translateZ: 0.001,
-            translateX: '-50%',
-            translateY: '-50%',
+            // translateX: '-50%',
+            // translateY: '-50%',
             scale: this.state.scale
           }}
           easing="ease"

--- a/src/components/preview/web/components/WebPreviewTopBar.tsx
+++ b/src/components/preview/web/components/WebPreviewTopBar.tsx
@@ -5,9 +5,7 @@ import { WeddingName } from '../../../../';
 
 export interface Props {
   backgroundColor?: string;
-  ownerName?: string;
-  fianceeName?: string;
-  hideWeddingName?: boolean;
+  title?: string;
 }
 
 const containerRules = backgroundColor =>
@@ -47,11 +45,7 @@ const expandButtonRules = css({
   backgroundColor: '#00cd36'
 });
 
-/**
- * Old theme styles
- */
-
-const websiteTitleRules = css(containerRules, {
+const titleRules = css(containerRules, {
   fontSize: '10px',
   textTransform: 'uppercase',
   fontWeight: '600',
@@ -61,20 +55,14 @@ const websiteTitleRules = css(containerRules, {
 
 export const WebPreviewTopBar: React.SFC<Props> = ({
   backgroundColor,
-  ownerName,
-  fianceeName,
-  hideWeddingName
+  title
+  // ownerName,
+  // fianceeName,
+  // hideWeddingName
 }) => {
   return (
     <div {...containerRules(backgroundColor)}>
-      {!hideWeddingName && (
-        <WeddingName
-          inline
-          owner={ownerName}
-          fiancee={fianceeName}
-          styles={websiteTitleRules}
-        />
-      )}
+      <div {...titleRules}>{title}</div>
       <div {...buttonContainerRules}>
         <div {...buttonRules} {...closeButtonRules} />
         <div {...buttonRules} {...minimizeButtonRules} />
@@ -85,6 +73,5 @@ export const WebPreviewTopBar: React.SFC<Props> = ({
 };
 
 WebPreviewTopBar.defaultProps = {
-  backgroundColor: '#E2E2E4',
-  hideWeddingName: false
+  backgroundColor: '#E2E2E4'
 };

--- a/src/components/preview/web/components/WebPreviewTopBar.tsx
+++ b/src/components/preview/web/components/WebPreviewTopBar.tsx
@@ -4,20 +4,20 @@ import { css } from 'glamor';
 import { WeddingName } from '../../../../';
 
 export interface Props {
-  ownerName: string;
-  fianceeName: string;
+  backgroundColor?: string;
+  ownerName?: string;
+  fianceeName?: string;
+  hideWeddingName?: boolean;
 }
 
-const containerRules = css({
-  width: '100%',
-  textAlign: 'center',
-  fontSize: '10px',
-  textTransform: 'uppercase',
-  fontWeight: '600',
-  letterSpacing: '.2px',
-  lineHeight: '36px',
-  minHeight: 36
-});
+const containerRules = backgroundColor =>
+  css({
+    backgroundColor,
+    width: '100%',
+    textAlign: 'center',
+    lineHeight: '36px',
+    minHeight: 36
+  });
 
 const buttonContainerRules = css({
   position: 'absolute',
@@ -52,18 +52,29 @@ const expandButtonRules = css({
  */
 
 const websiteTitleRules = css(containerRules, {
+  fontSize: '10px',
+  textTransform: 'uppercase',
+  fontWeight: '600',
+  letterSpacing: '.2px',
   margin: 0
 });
 
-export const DualPanePreviewTopBar = ({ ownerName, fianceeName }: Props) => {
+export const WebPreviewTopBar: React.SFC<Props> = ({
+  backgroundColor,
+  ownerName,
+  fianceeName,
+  hideWeddingName
+}) => {
   return (
-    <div {...containerRules}>
-      <WeddingName
-        inline
-        owner={ownerName}
-        fiancee={fianceeName}
-        styles={websiteTitleRules}
-      />
+    <div {...containerRules(backgroundColor)}>
+      {!hideWeddingName && (
+        <WeddingName
+          inline
+          owner={ownerName}
+          fiancee={fianceeName}
+          styles={websiteTitleRules}
+        />
+      )}
       <div {...buttonContainerRules}>
         <div {...buttonRules} {...closeButtonRules} />
         <div {...buttonRules} {...minimizeButtonRules} />
@@ -71,4 +82,9 @@ export const DualPanePreviewTopBar = ({ ownerName, fianceeName }: Props) => {
       </div>
     </div>
   );
+};
+
+WebPreviewTopBar.defaultProps = {
+  backgroundColor: '#E2E2E4',
+  hideWeddingName: false
 };

--- a/src/components/preview/web/dualPane/DualPanePreview.tsx
+++ b/src/components/preview/web/dualPane/DualPanePreview.tsx
@@ -8,6 +8,8 @@ import { DualPanePreviewTopBar } from './components/DualPanePreviewTopBar';
 import { DualPanePreviewLeft } from './components/DualPanePreviewLeft';
 import { DualPanePreviewRight } from './components/DualPanePreviewRight';
 
+import { PreviewWrapper } from '../PreviewWrapper';
+
 export interface Props {
   activeFont?: {
     key: string;
@@ -37,13 +39,7 @@ export interface Props {
   };
 }
 
-const previewContainerRules = css({
-  height: '100%',
-  width: '100%',
-  position: 'relative'
-});
-
-const previewRules = (height, width, scale: number) =>
+const previewRules = (height, width) =>
   css({
     borderRadius: '5px',
     boxShadow: '0 15px 60px 0 rgba(0,0,0,.1), 0 32px 75px 0 rgba(0,0,0,.1)',
@@ -55,7 +51,6 @@ const previewRules = (height, width, scale: number) =>
     pointerEvents: 'none',
     position: 'absolute',
     top: '50%',
-    transform: `translateZ(0) translate(-50%,-50%) scale(${scale})`,
     userSelect: 'none',
     width
   });
@@ -66,8 +61,6 @@ const contentRules = css({
 });
 
 class DualPanePreview extends React.Component<Props> {
-  private windowResizeSub;
-
   static defaultProps = {
     activeFont: null,
     theme: null,
@@ -75,40 +68,6 @@ class DualPanePreview extends React.Component<Props> {
       height: 500,
       width: 800
     }
-  };
-
-  state = {
-    scale: 1
-  };
-
-  componentDidMount() {
-    this.setResizeScale();
-  }
-
-  componentWillUnmount() {
-    this.windowResizeSub && this.windowResizeSub.unsubscribe();
-  }
-
-  private setResizeScale = () => {
-    const { width } = this.props.previewOptions;
-    const previewContainer = document.getElementById(
-      'dualPanePreviewContainer'
-    );
-    const SIDE_MARGIN = 20;
-    const windowResize$ = Observable.fromEvent(window, 'resize');
-    this.windowResizeSub = windowResize$.debounceTime(250).subscribe({
-      next: evt => {
-        const containerToPreviewRatio =
-          (previewContainer.offsetWidth - SIDE_MARGIN * 2) / width;
-        if (containerToPreviewRatio < 1) {
-          this.setState({
-            scale: containerToPreviewRatio
-          });
-        } else if (containerToPreviewRatio !== 1) {
-          this.setState({ scale: 1 });
-        }
-      }
-    });
   };
 
   private getFontOverrides = activeFont => {
@@ -212,45 +171,38 @@ class DualPanePreview extends React.Component<Props> {
       fontStylesheetLink
     } = this.getFontOverrides(activeFont);
     return (
-      <div
-        id="dualPanePreviewContainer"
-        data-website-preview="dual-pane"
-        {...previewContainerRules}
-      >
+      <Fragments>
         {fontStylesheetLink}
         {this.getStyleOverrides()}
-        <div
-          id="dualPanePreview"
-          className="joy-website-preview"
-          {...previewRules(
-            previewOptions.height,
-            previewOptions.width,
-            this.state.scale
-          )}
-        >
-          <DualPanePreviewTopBar
-            ownerName={ownerName}
-            fianceeName={fianceeName}
-          />
-          <div {...contentRules}>
-            <DualPanePreviewLeft
-              coverPhoto={coverPhoto}
-              fontOverrides={leftPaneHeaderRules}
-              fianceeName={fianceeName}
+        <PreviewWrapper for="dualPane" previewOptions={previewOptions}>
+          <div
+            className="joy-website-preview"
+            {...previewRules(previewOptions.height, previewOptions.width)}
+          >
+            <DualPanePreviewTopBar
               ownerName={ownerName}
-              message={message}
+              fianceeName={fianceeName}
             />
-            <DualPanePreviewRight
-              activeFont={activeFont}
-              backgroundColor={baseBackgroundColor}
-              color={baseTextColor}
-              eventDate={eventDate}
-              fontOverrides={rightPaneHeaderRules}
-              location={location}
-            />
+            <div {...contentRules}>
+              <DualPanePreviewLeft
+                coverPhoto={coverPhoto}
+                fontOverrides={leftPaneHeaderRules}
+                fianceeName={fianceeName}
+                ownerName={ownerName}
+                message={message}
+              />
+              <DualPanePreviewRight
+                activeFont={activeFont}
+                backgroundColor={baseBackgroundColor}
+                color={baseTextColor}
+                eventDate={eventDate}
+                fontOverrides={rightPaneHeaderRules}
+                location={location}
+              />
+            </div>
           </div>
-        </div>
-      </div>
+        </PreviewWrapper>
+      </Fragments>
     );
   }
 }

--- a/src/components/preview/web/dualPane/DualPanePreview.tsx
+++ b/src/components/preview/web/dualPane/DualPanePreview.tsx
@@ -47,12 +47,10 @@ const previewRules = (height, width) =>
     fontSize: '15px',
     fontWeight: '300',
     height,
-    left: '50%',
     pointerEvents: 'none',
-    position: 'absolute',
-    top: '50%',
     userSelect: 'none',
-    width
+    width,
+    minWidth: width
   });
 
 const contentRules = css({
@@ -164,7 +162,6 @@ class DualPanePreview extends React.Component<Props> {
       message
     } = this.getVisibleFields();
 
-    console.log(eventDate);
     let {
       leftPaneHeaderRules,
       rightPaneHeaderRules,

--- a/src/components/preview/web/dualPane/DualPanePreview.tsx
+++ b/src/components/preview/web/dualPane/DualPanePreview.tsx
@@ -4,11 +4,12 @@ import { margin } from 'glamor/utils';
 import { Observable, Subscription } from 'rxjs';
 
 import { WeddingName, CountdownTimer, Fragments } from '../../../../';
-import { DualPanePreviewTopBar } from './components/DualPanePreviewTopBar';
+import { WebPreviewTopBar } from '../components/WebPreviewTopBar';
 import { DualPanePreviewLeft } from './components/DualPanePreviewLeft';
 import { DualPanePreviewRight } from './components/DualPanePreviewRight';
 
 import { PreviewWrapper } from '../PreviewWrapper';
+import { getDefaultEventFields } from '../util';
 
 export interface Props {
   activeFont?: {
@@ -133,15 +134,13 @@ class DualPanePreview extends React.Component<Props> {
 
   private getVisibleFields = () => {
     const { ownerName, fianceeName, eventDate, location, message } = this.props;
-    return {
-      ownerName: ownerName || 'Romeo',
-      fianceeName: fianceeName || 'Juliet',
-      eventDate: eventDate || new Date().toString(),
-      location: location || 'San Francisco, CA',
-      message:
-        message ||
-        'We are so excited to celebrate with you. Help us capture our wedding with Joy.'
-    };
+    return getDefaultEventFields(
+      ownerName,
+      fianceeName,
+      eventDate,
+      location,
+      message
+    );
   };
 
   render() {
@@ -176,10 +175,7 @@ class DualPanePreview extends React.Component<Props> {
             className="joy-website-preview"
             {...previewRules(previewOptions.height, previewOptions.width)}
           >
-            <DualPanePreviewTopBar
-              ownerName={ownerName}
-              fianceeName={fianceeName}
-            />
+            <WebPreviewTopBar ownerName={ownerName} fianceeName={fianceeName} />
             <div {...contentRules}>
               <DualPanePreviewLeft
                 coverPhoto={coverPhoto}

--- a/src/components/preview/web/dualPane/DualPanePreview.tsx
+++ b/src/components/preview/web/dualPane/DualPanePreview.tsx
@@ -3,7 +3,12 @@ import { css } from 'glamor';
 import { margin } from 'glamor/utils';
 import { Observable, Subscription } from 'rxjs';
 
-import { WeddingName, CountdownTimer, Fragments } from '../../../../';
+import {
+  WeddingName,
+  CountdownTimer,
+  Fragments,
+  weddingNameString
+} from '../../../../';
 import { WebPreviewTopBar } from '../components/WebPreviewTopBar';
 import { DualPanePreviewLeft } from './components/DualPanePreviewLeft';
 import { DualPanePreviewRight } from './components/DualPanePreviewRight';
@@ -34,6 +39,7 @@ export interface Props {
   message?: string;
   ownerName?: string;
   theme?: string;
+  title?: string;
   previewOptions?: {
     height?: number;
     width?: number;
@@ -150,7 +156,8 @@ class DualPanePreview extends React.Component<Props> {
       baseTextColor,
       coverPhoto,
       previewOptions,
-      theme
+      theme,
+      title
     } = this.props;
 
     const {
@@ -175,7 +182,7 @@ class DualPanePreview extends React.Component<Props> {
             className="joy-website-preview"
             {...previewRules(previewOptions.height, previewOptions.width)}
           >
-            <WebPreviewTopBar ownerName={ownerName} fianceeName={fianceeName} />
+            <WebPreviewTopBar title={title} />
             <div {...contentRules}>
               <DualPanePreviewLeft
                 coverPhoto={coverPhoto}

--- a/src/components/preview/web/simpleLayout/SimpleLayoutPreview.tsx
+++ b/src/components/preview/web/simpleLayout/SimpleLayoutPreview.tsx
@@ -1,28 +1,30 @@
 import * as React from 'react';
 import { css } from 'glamor';
+import { PreviewWrapper } from '../PreviewWrapper';
 
-const previewContainerRules = css({
-  boxSizing: 'box-sizing',
-  height: '100%',
-  width: '100%',
-  position: 'relative'
-});
+export interface Props {
+  previewOptions?: {
+    height?: number;
+    width?: number;
+  };
+}
 
 const previewRules = css({
-  width: 1020,
-  height: '100%'
+  width: 640,
+  height: 876
 });
 
-export class SimpleLayoutPreview extends React.Component {
-  render() {
-    return (
-      <div
-        id="simpleLayoutPreviewContainer"
-        data-website-preview="simple-layout"
-        {...previewContainerRules}
-      >
-        <div {...previewRules}>I'm going to be the content</div>
-      </div>
-    );
+export const SimpleLayoutPreview: React.SFC<Props> = ({ previewOptions }) => {
+  return (
+    <PreviewWrapper for="simpleLayout" previewOptions={previewOptions}>
+      <div {...previewRules}>I'm going to be the content</div>
+    </PreviewWrapper>
+  );
+};
+
+SimpleLayoutPreview.defaultProps = {
+  previewOptions: {
+    width: 640,
+    height: 876
   }
-}
+};

--- a/src/components/preview/web/simpleLayout/SimpleLayoutPreview.tsx
+++ b/src/components/preview/web/simpleLayout/SimpleLayoutPreview.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { css } from 'glamor';
+
+const previewContainerRules = css({
+  boxSizing: 'box-sizing',
+  height: '100%',
+  width: '100%',
+  position: 'relative'
+});
+
+const previewRules = css({
+  width: 1020,
+  height: '100%'
+});
+
+export class SimpleLayoutPreview extends React.Component {
+  render() {
+    return (
+      <div
+        id="simpleLayoutPreviewContainer"
+        data-website-preview="simple-layout"
+        {...previewContainerRules}
+      >
+        <div {...previewRules}>I'm going to be the content</div>
+      </div>
+    );
+  }
+}

--- a/src/components/preview/web/simpleLayout/SimpleLayoutPreview.tsx
+++ b/src/components/preview/web/simpleLayout/SimpleLayoutPreview.tsx
@@ -1,23 +1,179 @@
 import * as React from 'react';
 import { css } from 'glamor';
+import * as moment from 'moment';
+
 import { PreviewWrapper } from '../PreviewWrapper';
+import { WebPreviewTopBar } from '../components/WebPreviewTopBar';
+import { Activefont, getDefaultEventFields } from '../util';
+
+import { WeddingName, CountdownTimer } from '../../../../';
 
 export interface Props {
+  activeFont?: Activefont;
+  coverPhoto?: string;
+  eventDate?: string;
+  fianceeName?: string;
+  location?: string;
+  message?: string;
+  ownerName?: string;
+  theme?: string;
   previewOptions?: {
     height?: number;
     width?: number;
   };
 }
 
-const previewRules = css({
-  width: 640,
-  height: 876
+const previewRules = (height, width) =>
+  css({
+    boxShadow:
+      '0 15.2px 38px 0 rgba(0, 0, 0, 0.24), 0 12px 12px 0 rgba(0, 0, 0, 0.18)',
+    display: 'flex',
+    flexDirection: 'column',
+    height,
+    minWidth: width,
+    margin: '20px 0',
+    position: 'relative',
+    width
+  });
+
+const contentRules = css({
+  alignItems: 'center',
+  border: '2px solid #e9e9e9',
+  borderTop: 'none',
+  borderBottom: 'none',
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  margin: '0 65px',
+  padding: '50px 30px'
 });
 
-export const SimpleLayoutPreview: React.SFC<Props> = ({ previewOptions }) => {
+const tabSectionRules = css({
+  display: 'flex',
+  listStyle: 'none',
+  justifyContent: 'space-between',
+  margin: '30px 0 25px 0',
+  padding: 0,
+  width: '100%',
+  ' > li': {
+    background: '#e9e9e9',
+    borderRadius: 20,
+    height: 13,
+    width: 40
+  }
+});
+
+const coverPhotoRules = image =>
+  css({
+    // background: `url(${image}) center / contain no-repeat`,
+    height: 300,
+    backgroundColor: '#e9e9e9',
+    width: '100%'
+  });
+
+const bodySectionRules = css({
+  fontSize: '.8em',
+  margin: '25px 0',
+  textAlign: 'center',
+  width: '60%',
+  ' > *': {
+    margin: '15px 0'
+  }
+});
+
+const logisticsContainerRules = css({
+  transform: 'scale(.8)'
+});
+
+const locationRules = css({
+  fontSize: '25px',
+  fontWeight: 300,
+  lineHeight: '36px',
+  margin: 0,
+  marginBottom: 10
+});
+
+const dateRules = css({
+  fontSize: '12px',
+  fontWeight: 400,
+  lineHeight: '17px',
+  margin: '0 0 10px'
+});
+
+const ctaButtonRules = css({
+  fontWeight: '400',
+  lineHeight: '28px',
+  border: '1.4px solid',
+  borderRadius: '5px',
+  marginTop: 30,
+  minWidth: '80px',
+  fontSize: '11px',
+  padding: '0 20px',
+  textAlign: 'center'
+});
+
+const getVisibleFields = weddingInfo => {
+  return getDefaultEventFields(
+    weddingInfo.ownerName,
+    weddingInfo.fianceeName,
+    weddingInfo.eventDate,
+    weddingInfo.location,
+    weddingInfo.message
+  );
+};
+
+export const SimpleLayoutPreview: React.SFC<Props> = ({
+  children,
+  activeFont,
+  coverPhoto,
+  previewOptions,
+  theme,
+  ...weddingInfo
+}) => {
+  const {
+    ownerName,
+    fianceeName,
+    eventDate,
+    location,
+    message
+  } = getVisibleFields(weddingInfo);
+
+  const eventDateMoment = moment(eventDate);
+
   return (
     <PreviewWrapper for="simpleLayout" previewOptions={previewOptions}>
-      <div {...previewRules}>I'm going to be the content</div>
+      <div {...previewRules(previewOptions.height, previewOptions.width)}>
+        <WebPreviewTopBar hideWeddingName />
+        <div {...contentRules}>
+          <div>
+            <WeddingName owner={ownerName} fiancee={fianceeName} />
+          </div>
+          <ul data-section="tabs" {...tabSectionRules}>
+            <li />
+            <li />
+            <li />
+            <li />
+            <li />
+            <li />
+            <li />
+            <li />
+          </ul>
+          <div {...coverPhotoRules(coverPhoto)} />
+          <div data-section="body" {...bodySectionRules}>
+            <div>TWIRLYBIT</div>
+            <div data-section="greeting">{message}</div>
+            <div data-section="logistics" {...logisticsContainerRules}>
+              <h2 {...locationRules}>{location}</h2>
+              <h4 {...dateRules}>
+                {eventDateMoment.isValid() &&
+                  eventDateMoment.format('dddd, MMMM D, YYYY')}
+              </h4>
+              <CountdownTimer eventDate={eventDate} fontSize="12" />
+              <div {...ctaButtonRules}>RSVP HERE</div>
+            </div>
+          </div>
+        </div>
+      </div>
     </PreviewWrapper>
   );
 };

--- a/src/components/preview/web/simpleLayout/SimpleLayoutPreview.tsx
+++ b/src/components/preview/web/simpleLayout/SimpleLayoutPreview.tsx
@@ -143,7 +143,7 @@ export const SimpleLayoutPreview: React.SFC<Props> = ({
   return (
     <PreviewWrapper for="simpleLayout" previewOptions={previewOptions}>
       <div {...previewRules(previewOptions.height, previewOptions.width)}>
-        <WebPreviewTopBar hideWeddingName />
+        <WebPreviewTopBar />
         <div {...contentRules}>
           <div>
             <WeddingName owner={ownerName} fiancee={fianceeName} />

--- a/src/components/preview/web/util.ts
+++ b/src/components/preview/web/util.ts
@@ -1,0 +1,30 @@
+export interface Activefont {
+  key: string;
+  fontFamily?: string;
+  fontWeight?: string;
+  h1?: string;
+  h2?: string;
+  h3?: string;
+  letterSpacing?: string;
+  lineHeight?: string;
+  textTransform: string;
+  _comment?: string;
+}
+
+export const getDefaultEventFields = (
+  ownerName,
+  fianceeName,
+  eventDate,
+  location,
+  message
+) => {
+  return {
+    ownerName: ownerName || 'Romeo',
+    fianceeName: fianceeName || 'Juliet',
+    eventDate: eventDate || new Date().toString(),
+    location: location || 'San Francisco, CA',
+    message:
+      message ||
+      'We are so excited to celebrate with you. Help us capture our wedding with Joy.'
+  };
+};

--- a/src/components/weddingName/WeddingName.tsx
+++ b/src/components/weddingName/WeddingName.tsx
@@ -17,7 +17,7 @@ export interface Props {
 
 const baseRules = css({
   fontWeight: 100,
-  marginSize: 0
+  margin: 0
 });
 
 const getNameOrder = (
@@ -53,7 +53,7 @@ const shouldHaveTrailingAmpersand = (
 const WeddingName: React.SFC<Props> = ({
   className,
   id,
-  owner,
+  owner = '',
   fiancee = '',
   inline,
   styles,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ import {
   WeddingName,
   DualPanePreview,
   CountdownTimer,
-  SpinnerLoader
+  SpinnerLoader,
+  SimpleLayoutPreview
 } from './components';
 
 // Styles
@@ -67,6 +68,7 @@ export {
   weddingNameString,
   WeddingName,
   DualPanePreview,
+  SimpleLayoutPreview,
   CountdownTimer,
   Colors,
   SpinnerLoader

--- a/stories/websitePreview/websitePreview.tsx
+++ b/stories/websitePreview/websitePreview.tsx
@@ -83,6 +83,10 @@ stories.add('Dual Pane', () => {
 });
 
 stories.add('Simple Layout', () => {
+  // const coverPhoto = text(
+  //   'Cover Photo',
+  //   'https://s3-us-west-2.amazonaws.com/joy-public-assets-bucket/ktran-development/hero_jesslynn_daniel.jpg'
+  // );
   return (
     <div>
       <SimpleLayoutPreview />

--- a/stories/websitePreview/websitePreview.tsx
+++ b/stories/websitePreview/websitePreview.tsx
@@ -12,7 +12,7 @@ import {
 } from '@storybook/addon-knobs';
 
 import { SyntaxHighlight } from '../utils/syntax';
-import { Button, DualPanePreview } from '../../src';
+import { Button, DualPanePreview, SimpleLayoutPreview } from '../../src';
 const JOY_THEMES = require('./joyStyles.json');
 const JOY_FONTS = require('./joyFonts.json');
 
@@ -78,6 +78,14 @@ stories.add('Dual Pane', () => {
       />
       `}
       />
+    </div>
+  );
+});
+
+stories.add('Simple Layout', () => {
+  return (
+    <div>
+      <SimpleLayoutPreview />
     </div>
   );
 });

--- a/stories/websitePreview/websitePreview.tsx
+++ b/stories/websitePreview/websitePreview.tsx
@@ -12,7 +12,12 @@ import {
 } from '@storybook/addon-knobs';
 
 import { SyntaxHighlight } from '../utils/syntax';
-import { Button, DualPanePreview, SimpleLayoutPreview } from '../../src';
+import {
+  Button,
+  DualPanePreview,
+  SimpleLayoutPreview,
+  weddingNameString
+} from '../../src';
 const JOY_THEMES = require('./joyStyles.json');
 const JOY_FONTS = require('./joyFonts.json');
 
@@ -61,6 +66,7 @@ stories.add('Dual Pane', () => {
           ownerName={ownerName}
           fianceeName={fianceeName}
           theme={theme}
+          title={weddingNameString(ownerName, fianceeName)}
         />
       </div>
       <SyntaxHighlight
@@ -83,10 +89,6 @@ stories.add('Dual Pane', () => {
 });
 
 stories.add('Simple Layout', () => {
-  // const coverPhoto = text(
-  //   'Cover Photo',
-  //   'https://s3-us-west-2.amazonaws.com/joy-public-assets-bucket/ktran-development/hero_jesslynn_daniel.jpg'
-  // );
   return (
     <div>
       <SimpleLayoutPreview />


### PR DESCRIPTION
This is very bare bones for now - reason being: i want to use this to quickly prototype the new design panel implementation that requires both the old (dual pane) and new preview (simple)

![newtemplatepreview](https://user-images.githubusercontent.com/8356564/33692820-321fc472-daa4-11e7-9ae8-da5067db9608.jpg)
