### PR TITLE
When the modal unmounts, put the scrollbar back

### DIFF
--- a/src/components/modal/ModalPortal.tsx
+++ b/src/components/modal/ModalPortal.tsx
@@ -157,6 +157,7 @@ export class ModalPortal extends React.Component<Props, State> {
   }
   componentWillUnmount() {
     const { onUnmount } = this.props;
+    document.body.style.overflow = 'auto';
     onUnmount && onUnmount(this.props);
   }
 


### PR DESCRIPTION
When the dialog unmounts we should set overflow back to `auto`